### PR TITLE
Expand [Default] value to the default values of stickyElementNames and sortAttributes.

### DIFF
--- a/Projects/CsProjArrange/CsProjArrange/CsProjArrangeConsole.cs
+++ b/Projects/CsProjArrange/CsProjArrange/CsProjArrangeConsole.cs
@@ -34,13 +34,15 @@ namespace CsProjArrange
             string outputFile = null;
             IEnumerable<string> stickyElementNames = null;
             IEnumerable<string> sortAttributes = null;
+            IEnumerable<string> keepOrderElementNames = null;
             CsProjArrange.ArrangeOptions options = CsProjArrange.ArrangeOptions.All;
 
             OptionSet os = new OptionSet(){
                 { "?|help", "Display this usage message.", x => help = x != null },
                 { "i|input=", "Set the input file name. Standard input is the default.", x => inputFile = x },
                 { "o|output=", "Set the output file name. Standard output is the default.", x => outputFile = x },
-                { "s|sticky=", "Comma separated list of elements names which should be stuck to the top.", x => stickyElementNames = x.Split(',') },
+                { "s|sticky=", "Comma separated list of element names which should be stuck to the top.", x => stickyElementNames = x.Split(',') },
+                { "k|keeporder=", "Comma separated list of element names where children should not be sorted.", x => keepOrderElementNames = x.Split(',') },
                 { "a|attributes=", "Comma separated list of attributes to sort on.", x => sortAttributes = x.Split(',') },
                 { "p|options=", "Specify options", x => Enum.TryParse<CsProjArrange.ArrangeOptions>(x, out options) },
             };
@@ -64,7 +66,7 @@ namespace CsProjArrange
             }
 
             try {
-                new CsProjArrange().Arrange(inputFile, outputFile ?? inputFile, stickyElementNames, sortAttributes, options);
+                new CsProjArrange().Arrange(inputFile, outputFile ?? inputFile, stickyElementNames, keepOrderElementNames, sortAttributes, options);
             } catch (Exception e) {
                 Console.Error.WriteLine("Encountered an error: {0}", e.Message);
             }

--- a/Projects/CsProjArrange/CsProjArrange/CsProjArrangeConsole.cs
+++ b/Projects/CsProjArrange/CsProjArrange/CsProjArrangeConsole.cs
@@ -32,7 +32,7 @@ namespace CsProjArrange
             bool help = false;
             string inputFile = null;
             string outputFile = null;
-            IList<string> stickyElementNames = null;
+            IEnumerable<string> stickyElementNames = null;
             IEnumerable<string> sortAttributes = null;
             CsProjArrange.ArrangeOptions options = CsProjArrange.ArrangeOptions.All;
 

--- a/README.md
+++ b/README.md
@@ -35,8 +35,10 @@ Here is the help listing you can see by running `CsProjArrange -?`.
                                    default.
       -o, --output=VALUE         Set the output file name. Standard output is the
                                    default.
-      -s, --sticky=VALUE         Comma separated list of elements names which
+      -s, --sticky=VALUE         Comma separated list of element names which
                                    should be stuck to the top.
+      -k, --keeporder=VALUE      Comma separated list of element names where
+                                   children should not be sorted.
       -a, --attributes=VALUE     Comma separated list of attributes to sort on.
       -p, --options=VALUE        Specify options
 
@@ -59,6 +61,8 @@ When no command line options are specified, the following defaults take effect.
    - `None`
    - `When`
    - `Otherwise`
+ - The list of elements where children should not be sorted is the `[Default]` value,
+     which expands to just `Target`.
  - The list of attributes is the `[Default]` value, which expands to just `Include`.
  - All of the following options are selected:
    - `CombineRootElements`

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ When no command line options are specified, the following defaults take effect.
 
  - The input comes from standard input.
  - The output goes to standard output.
- - The list of sticky element names is:
+ - The list of sticky element names is the `[Default]` value, which expands to:
    - `Task`
    - `PropertyGroup`
    - `ItemGroup`
@@ -59,7 +59,7 @@ When no command line options are specified, the following defaults take effect.
    - `None`
    - `When`
    - `Otherwise`
- - The list of attributes just include `Include`.
+ - The list of attributes is the `[Default]` value, which expands to just `Include`.
  - All of the following options are selected:
    - `CombineRootElements`
      - This will combine root elements which have the same name and the same attribute values.


### PR DESCRIPTION
Great tool!

I needed to add some more attributes to the sticky list, but didn't want to repeat the default values, so I made [Default] expand to the given default values.

Edit: Most of the my problems arose from reordering tasks of a Target element, so I added an option to exclude some element names (defaults to only Target) from reordering.