### PR TITLE
Expand [Default] value to the default values of stickyElementNames and sortAttributes, take 2

### DIFF
--- a/Projects/CsProjArrange/CsProjArrange.Tests/CsProjArrange.Tests.csproj
+++ b/Projects/CsProjArrange/CsProjArrange.Tests/CsProjArrange.Tests.csproj
@@ -96,6 +96,12 @@
   <ItemGroup>
     <EmbeddedResource Include="TestData\Expected\SortingInputCombineRootElements.xml" />
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="TestData\Input\DoNotSortInput.xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="TestData\Expected\DoNotSortInput.xml" />
+  </ItemGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
       <ItemGroup>

--- a/Projects/CsProjArrange/CsProjArrange.Tests/CsProjArrangeStrategyTests.cs
+++ b/Projects/CsProjArrange/CsProjArrange.Tests/CsProjArrangeStrategyTests.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.Collections.Generic;
 using System.Xml.Linq;
 using CsProjArrange.Tests.Helpers;
 using FluentAssertions;
@@ -11,9 +9,15 @@ namespace CsProjArrange.Tests
     [TestFixture]
     public class CsProjArrangeStrategyTests
     {
-        private static CsProjArrangeStrategy CreateTestTarget(IList<string> stickyElementNames, IEnumerable<string> sortAttributes, CsProjArrange.ArrangeOptions options)
+        private static CsProjArrangeStrategy CreateTestTarget(IEnumerable<string> stickyElementNames, IEnumerable<string> keepOrderElementNames,
+            IEnumerable<string> sortAttributes, CsProjArrange.ArrangeOptions options)
         {
-            return new CsProjArrangeStrategy(stickyElementNames, sortAttributes, options);
+            return new CsProjArrangeStrategy(stickyElementNames, keepOrderElementNames, sortAttributes, options);
+        }
+
+        private static CsProjArrangeStrategy CreateDefaultTestTarget(CsProjArrange.ArrangeOptions options)
+        {
+            return new CsProjArrangeStrategy(null, null, null, options);
         }
 
         [Test]
@@ -22,7 +26,7 @@ namespace CsProjArrange.Tests
         {
             XDocument inputDocument =
                 EmbeddedResourceHelper.ExtractManifestResourceAsXDocument("TestData.Input.CsProjArrangeInput.csproj");
-            var target = CreateTestTarget(null, null, CsProjArrange.ArrangeOptions.CombineRootElements);
+            var target = CreateDefaultTestTarget(CsProjArrange.ArrangeOptions.CombineRootElements);
 
             target.Arrange(inputDocument);
 
@@ -34,7 +38,7 @@ namespace CsProjArrange.Tests
         {
             XDocument inputDocument =
                 EmbeddedResourceHelper.ExtractManifestResourceAsXDocument("TestData.Input.CsProjArrangeInput.csproj");
-            var target = CreateTestTarget( null, null, CsProjArrange.ArrangeOptions.None);
+            var target = CreateDefaultTestTarget(CsProjArrange.ArrangeOptions.None);
 
             // Act
             target.Arrange(inputDocument);
@@ -49,7 +53,7 @@ namespace CsProjArrange.Tests
         {
             XDocument inputDocument =
                 EmbeddedResourceHelper.ExtractManifestResourceAsXDocument("TestData.Input.CsProjArrangeInput.csproj");
-            var target = CreateTestTarget(null, null, CsProjArrange.ArrangeOptions.CombineRootElements);
+            var target = CreateDefaultTestTarget(CsProjArrange.ArrangeOptions.CombineRootElements);
 
             // Act
             target.Arrange(inputDocument);
@@ -64,7 +68,7 @@ namespace CsProjArrange.Tests
         {
             XDocument inputDocument =
                 EmbeddedResourceHelper.ExtractManifestResourceAsXDocument("TestData.Input.SortingInput.xml");
-            var target = CreateTestTarget(null, null, CsProjArrange.ArrangeOptions.None);
+            var target = CreateDefaultTestTarget(CsProjArrange.ArrangeOptions.None);
 
             // Act
             target.Arrange(inputDocument);
@@ -78,7 +82,7 @@ namespace CsProjArrange.Tests
         {
             XDocument inputDocument =
                 EmbeddedResourceHelper.ExtractManifestResourceAsXDocument("TestData.Input.SortingInput.xml");
-            var target = CreateTestTarget(null, null, CsProjArrange.ArrangeOptions.CombineRootElements);
+            var target = CreateDefaultTestTarget(CsProjArrange.ArrangeOptions.CombineRootElements);
 
             target.Arrange(inputDocument);
 

--- a/Projects/CsProjArrange/CsProjArrange.Tests/CsProjArrangeStrategyTests.cs
+++ b/Projects/CsProjArrange/CsProjArrange.Tests/CsProjArrangeStrategyTests.cs
@@ -78,6 +78,20 @@ namespace CsProjArrange.Tests
         }
 
         [Test]
+        public void Arrange_when_some_elements_are_not_to_be_sorted_sort_the_other_elements_csproj()
+        {
+            XDocument inputDocument =
+                EmbeddedResourceHelper.ExtractManifestResourceAsXDocument("TestData.Input.DoNotSortInput.xml");
+            var target = CreateTestTarget(null, new[] {"DoNotSort"}, null, CsProjArrange.ArrangeOptions.None);
+
+            // Act
+            target.Arrange(inputDocument);
+
+            XDocument expectedDocument = EmbeddedResourceHelper.ExtractManifestResourceAsXDocument("TestData.Expected.DoNotSortInput.xml");
+            inputDocument.ToString().Should().BeEquivalentTo(expectedDocument.ToString());
+        }
+
+        [Test]
         public void Arrange_when_combineRootElements_should_return_sorted_csproj()
         {
             XDocument inputDocument =

--- a/Projects/CsProjArrange/CsProjArrange.Tests/TestData/Expected/CsProjArrangeExpectedCombineRootElements.csproj
+++ b/Projects/CsProjArrange/CsProjArrange.Tests/TestData/Expected/CsProjArrangeExpectedCombineRootElements.csproj
@@ -77,6 +77,10 @@
       <Visible>False</Visible>
     </BootstrapperPackage>
   </ItemGroup>
+  <Target Name="SampleTarget">
+    <Message Text="This is a sample target" />
+    <Exec Command="echo done" />
+  </Target>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Projects/CsProjArrange/CsProjArrange.Tests/TestData/Expected/CsProjArrangeExpectedDefault.csproj
+++ b/Projects/CsProjArrange/CsProjArrange.Tests/TestData/Expected/CsProjArrangeExpectedDefault.csproj
@@ -83,6 +83,10 @@
       <Visible>False</Visible>
     </BootstrapperPackage>
   </ItemGroup>
+  <Target Name="SampleTarget">
+    <Message Text="This is a sample target" />
+    <Exec Command="echo done" />
+  </Target>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Projects/CsProjArrange/CsProjArrange.Tests/TestData/Expected/DoNotSortInput.xml
+++ b/Projects/CsProjArrange/CsProjArrange.Tests/TestData/Expected/DoNotSortInput.xml
@@ -1,0 +1,15 @@
+﻿<Project ToolsVersion="12.0" DefaultTargets="Build">
+  <Sort>
+    <A />
+    <B />
+    <C />
+  </Sort>
+  <DoNotSort>
+    <F />
+    <E>
+      <A />
+      <B />
+    </E>
+    <D />
+  </DoNotSort>
+</Project>

--- a/Projects/CsProjArrange/CsProjArrange.Tests/TestData/Input/CsProjArrangeInput.csproj
+++ b/Projects/CsProjArrange/CsProjArrange.Tests/TestData/Input/CsProjArrangeInput.csproj
@@ -83,6 +83,10 @@
       <Visible>False</Visible>
     </BootstrapperPackage>
   </ItemGroup>
+  <Target Name="SampleTarget">
+    <Message Text="This is a sample target" />
+    <Exec Command="echo done" />
+  </Target>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Projects/CsProjArrange/CsProjArrange.Tests/TestData/Input/DoNotSortInput.xml
+++ b/Projects/CsProjArrange/CsProjArrange.Tests/TestData/Input/DoNotSortInput.xml
@@ -1,0 +1,15 @@
+﻿<Project ToolsVersion="12.0" DefaultTargets="Build">
+  <Sort>
+    <C />
+    <B />
+    <A />
+  </Sort>
+  <DoNotSort>
+    <F />
+    <E>
+      <B />
+      <A />
+    </E>
+    <D />
+  </DoNotSort>
+</Project>

--- a/Projects/CsProjArrange/CsProjArrange/CsProjArrangeConsole.cs
+++ b/Projects/CsProjArrange/CsProjArrange/CsProjArrangeConsole.cs
@@ -33,6 +33,7 @@ namespace CsProjArrange
             string inputFile = null;
             string outputFile = null;
             IEnumerable<string> stickyElementNames = null;
+            IEnumerable<string> keepOrderElementNames = null;
             IEnumerable<string> sortAttributes = null;
             CsProjArrange.ArrangeOptions options = CsProjArrange.ArrangeOptions.All;
 
@@ -40,7 +41,8 @@ namespace CsProjArrange
                 { "?|help", "Display this usage message.", x => help = x != null },
                 { "i|input=", "Set the input file name. Standard input is the default.", x => inputFile = x },
                 { "o|output=", "Set the output file name. Standard output is the default.", x => outputFile = x },
-                { "s|sticky=", "Comma separated list of elements names which should be stuck to the top.", x => stickyElementNames = x.Split(',') },
+                { "s|sticky=", "Comma separated list of element names which should be stuck to the top.", x => stickyElementNames = x.Split(',') },
+                { "k|keeporder=", "Comma separated list of element names where children should not be sorted.", x => keepOrderElementNames = x.Split(',') },
                 { "a|attributes=", "Comma separated list of attributes to sort on.", x => sortAttributes = x.Split(',') },
                 { "p|options=", "Specify options", x => Enum.TryParse<CsProjArrange.ArrangeOptions>(x, out options) },
             };
@@ -65,7 +67,7 @@ namespace CsProjArrange
 
             try
             {
-                var csProjArrange = CreateCsProjArrange(stickyElementNames, sortAttributes, options);
+                var csProjArrange = CreateCsProjArrange(stickyElementNames, keepOrderElementNames, sortAttributes, options);
                 csProjArrange.Arrange(inputFile, outputFile ?? inputFile);
             }
             catch (Exception e) {
@@ -73,10 +75,10 @@ namespace CsProjArrange
             }
         }
 
-        private static CsProjArrange CreateCsProjArrange(IEnumerable<string> stickyElementNames, IEnumerable<string> sortAttributes,
-            CsProjArrange.ArrangeOptions options)
+        private static CsProjArrange CreateCsProjArrange(IEnumerable<string> stickyElementNames, IEnumerable<string> keepOrderElementNames,
+            IEnumerable<string> sortAttributes, CsProjArrange.ArrangeOptions options)
         {
-            CsProjArrangeStrategy strategy = new CsProjArrangeStrategy(stickyElementNames, sortAttributes, options);
+            CsProjArrangeStrategy strategy = new CsProjArrangeStrategy(stickyElementNames, keepOrderElementNames, sortAttributes, options);
             CsProjArrange csProjArrange = new CsProjArrange(strategy);
             return csProjArrange;
         }
@@ -87,7 +89,7 @@ namespace CsProjArrange
         /// <param name="os"></param>
         private void Help(OptionSet os)
         {
-            Console.WriteLine("Usage: " + System.AppDomain.CurrentDomain.FriendlyName + " [-?|--help] [-iINPUT|--input=INPUT] [-oOUTPUT|--output=OUTPUT] [-sSTICKY|--sticky=STICKY] [-aSORTATTRIBUTES|--attributes=SORTATTRIBUTES]");
+            Console.WriteLine("Usage: " + System.AppDomain.CurrentDomain.FriendlyName + " [-?|--help] [-iINPUT|--input=INPUT] [-oOUTPUT|--output=OUTPUT] [-sSTICKY|--sticky=STICKY] [-kKEEPORDER|--keeporder=KEEPORDER] [-aSORTATTRIBUTES|--attributes=SORTATTRIBUTES]");
             Console.WriteLine();
             Console.WriteLine("Option:");
             os.WriteOptionDescriptions(Console.Out);

--- a/Projects/CsProjArrange/CsProjArrange/CsProjArrangeConsole.cs
+++ b/Projects/CsProjArrange/CsProjArrange/CsProjArrangeConsole.cs
@@ -32,7 +32,7 @@ namespace CsProjArrange
             bool help = false;
             string inputFile = null;
             string outputFile = null;
-            IList<string> stickyElementNames = null;
+            IEnumerable<string> stickyElementNames = null;
             IEnumerable<string> sortAttributes = null;
             CsProjArrange.ArrangeOptions options = CsProjArrange.ArrangeOptions.All;
 
@@ -73,7 +73,7 @@ namespace CsProjArrange
             }
         }
 
-        private static CsProjArrange CreateCsProjArrange(IList<string> stickyElementNames, IEnumerable<string> sortAttributes,
+        private static CsProjArrange CreateCsProjArrange(IEnumerable<string> stickyElementNames, IEnumerable<string> sortAttributes,
             CsProjArrange.ArrangeOptions options)
         {
             CsProjArrangeStrategy strategy = new CsProjArrangeStrategy(stickyElementNames, sortAttributes, options);

--- a/Projects/CsProjArrange/CsProjArrange/CsProjArrangeStrategy.cs
+++ b/Projects/CsProjArrange/CsProjArrange/CsProjArrangeStrategy.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Xml;
 using System.Xml.Linq;
 
@@ -12,39 +11,57 @@ namespace CsProjArrange
     /// </summary>
     public class CsProjArrangeStrategy
     {
+        private const string DefaultMarker = "[Default]";
+
+        private readonly string[] _defaultStickyElementNames =
+        {
+            // Primary
+            "Task",
+            "PropertyGroup",
+            "ItemGroup",
+            "Target",
+            // Secondary: PropertyGroup
+            "Configuration",
+            "Platform",
+            // Secondary: ItemGroup
+            "ProjectReference",
+            "Reference",
+            "Compile",
+            "Folder",
+            "Content",
+            "None",
+            // Secondary: Choose
+            "When",
+            "Otherwise",
+        };
+
+        private readonly string[] _defaultSortAttributes =
+        {
+            "Include",
+        };
+
         private AttributeKeyComparer _attributeKeyComparer;
         private NodeNameComparer _nodeNameComparer;
-        private IList<string> _stickyElementNames;
-        private readonly IEnumerable<string> _sortAttributes;
+        private readonly List<string> _stickyElementNames;
+        private readonly List<string> _sortAttributes;
         private readonly CsProjArrange.ArrangeOptions _options;
 
-        public CsProjArrangeStrategy(IList<string> stickyElementNames, IEnumerable<string> sortAttributes, CsProjArrange.ArrangeOptions options)
+        public CsProjArrangeStrategy(IEnumerable<string> stickyElementNames, IEnumerable<string> sortAttributes, CsProjArrange.ArrangeOptions options)
         {
-            _stickyElementNames = stickyElementNames ?? new string[]
-            {
-                // Primary
-                "Task",
-                "PropertyGroup",
-                "ItemGroup",
-                "Target",
-                // Secondary: PropertyGroup
-                "Configuration",
-                "Platform",
-                // Secondary: ItemGroup
-                "ProjectReference",
-                "Reference",
-                "Compile",
-                "Folder",
-                "Content",
-                "None",
-                // Secondary: Choose
-                "When",
-                "Otherwise",
-            };
-
-
-            _sortAttributes = sortAttributes;
+            _stickyElementNames = (stickyElementNames ?? new[] {DefaultMarker}).ToList();
+            ReplaceDefaultMarker(_stickyElementNames, _defaultStickyElementNames);
+            _sortAttributes = (sortAttributes ?? new[] {DefaultMarker}).ToList();
+            ReplaceDefaultMarker(_sortAttributes, _defaultSortAttributes);
             _options = options;
+        }
+
+        private static void ReplaceDefaultMarker(List<string> collection, IList<string> defaultValues)
+        {
+            if (collection.Contains(DefaultMarker))
+            {
+                collection.Remove(DefaultMarker);
+                collection.AddRange(defaultValues);
+            }
         }
 
         private void ArrangeElementByNameThenAttributes(XElement element)
@@ -81,14 +98,6 @@ namespace CsProjArrange
 
         private AttributeKeyComparer CreateAttributeKeyComparer(IEnumerable<string> sortAttributes)
         {
-            if (sortAttributes == null)
-            {
-                sortAttributes = new string[]
-                {
-                    "Include",
-                };
-            }
-
             return new AttributeKeyComparer(sortAttributes);
         }
 

--- a/README.md
+++ b/README.md
@@ -35,8 +35,10 @@ Here is the help listing you can see by running `CsProjArrange -?`.
                                    default.
       -o, --output=VALUE         Set the output file name. Standard output is the
                                    default.
-      -s, --sticky=VALUE         Comma separated list of elements names which
+      -s, --sticky=VALUE         Comma separated list of element names which
                                    should be stuck to the top.
+      -k, --keeporder=VALUE      Comma separated list of element names where
+                                   children should not be sorted.
       -a, --attributes=VALUE     Comma separated list of attributes to sort on.
       -p, --options=VALUE        Specify options
 
@@ -59,6 +61,8 @@ When no command line options are specified, the following defaults take effect.
    - `None`
    - `When`
    - `Otherwise`
+ - The list of elements where children should not be sorted is the `[Default]` value,
+     which expands to just `Target`.
  - The list of attributes is the `[Default]` value, which expands to just `Include`.
  - All of the following options are selected:
    - `CombineRootElements`

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ When no command line options are specified, the following defaults take effect.
 
  - The input comes from standard input.
  - The output goes to standard output.
- - The list of sticky element names is:
+ - The list of sticky element names is the `[Default]` value, which expands to:
    - `Task`
    - `PropertyGroup`
    - `ItemGroup`
@@ -59,7 +59,7 @@ When no command line options are specified, the following defaults take effect.
    - `None`
    - `When`
    - `Otherwise`
- - The list of attributes just include `Include`.
+ - The list of attributes is the `[Default]` value, which expands to just `Include`.
  - All of the following options are selected:
    - `CombineRootElements`
      - This will combine root elements which have the same name and the same attribute values.


### PR DESCRIPTION
Same as #4, but rebased to version 1.1
===
I needed to add some more attributes to the sticky list, but didn't want to repeat the default values, so I made [Default] expand to the given default values.

Edit: Most of the my problems arose from reordering tasks of a Target element, so I added an option to exclude some element names (defaults to only Target) from reordering.