### PR TITLE
Sort elements along with comments preceding them.

### DIFF
--- a/Projects/CsProjArrange/CsProjArrange/NodeNameComparer.cs
+++ b/Projects/CsProjArrange/CsProjArrange/NodeNameComparer.cs
@@ -38,7 +38,7 @@ namespace CsProjArrange
             var stickyElement2 = StickyElementNames.IndexOf(yName);
             if ((stickyElement1 == -1) && (stickyElement2 == -1))
             {
-                return String.Compare(xName, yName);
+                return String.Compare(xName, yName, StringComparison.InvariantCulture);
             }
             return Compare(stickyElement1, stickyElement2);
         }


### PR DESCRIPTION
CSProjArrange produces unnecessary changes in case when .csproj file contains comments.
In order to preserve location of comment next to the element following the comment we need to sort elements along with comments preceding them.
This merge request is aimed to fix this case. It transforms the collection of nodes into collection of pairs node/comment and performs sorting. Then it unfolds comments from the elements.